### PR TITLE
implementation of dynamic imports with unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,34 +8,35 @@
   "scripts": {
     "prepublish": "bitbundler",
     "build": "bitbundler",
-    "test": "mocha --compilers js:babel-register"
+    "test": "mocha --require babel-register"
   },
   "engine": {
     "node": ">=4"
   },
   "dependencies": {
     "acorn": "~5.3.0",
-    "belty": "^5.1.0"
+    "acorn-dynamic-import": "^2.0.2",
+    "belty": "^5.2.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
     "babelify": "^8.0.0",
-    "bit-bundler": "^10.0.0",
-    "bit-bundler-extractsm": "^2.1.1",
-    "bit-bundler-minifyjs": "^3.0.3",
+    "bit-bundler": "^10.1.0",
+    "bit-bundler-extractsm": "^2.1.3",
+    "bit-bundler-minifyjs": "^3.1.0",
     "bit-loader-babel": "^2.0.0",
-    "bit-loader-eslint": "^1.2.1",
+    "bit-loader-eslint": "^1.3.0",
     "chai": "~4.1.2",
-    "eslint": "^4.12.1",
-    "eslint-config-standard": "^10.2.1",
+    "eslint": "^4.15.0",
+    "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "mocha": "~4.1.0",
-    "sinon": "~4.1.2"
+    "sinon": "~4.1.5"
   },
   "browser": {},
   "directories": {

--- a/test/spec/index.js
+++ b/test/spec/index.js
@@ -1,176 +1,189 @@
 import { expect } from "chai";
-import sinon from "sinon";
 import pulldeps from "../../src/index";
 
 describe("Test suite", function() {
-  var dependecies;
+  var dependencies;
 
-  describe("When parsing a single `import` with the default named export ", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("import test from 'test'").dependencies;
+  describe("When parsing a single dynamic `import`", function() {
+    before(function() {
+      dependencies = pulldeps("import('module-name');").dependencies;
     });
 
     it("then dependencies length is `1`", function() {
-      expect(dependecies.length).to.equal(1);
+      expect(dependencies).to.have.lengthOf(1);
+    });
+
+    it("then dependencies[0] is `module-name`", function() {
+      expect(dependencies[0].name).to.equal("module-name");
+    });
+  });
+
+  describe("When parsing a single `import` with the default named export ", function() {
+    before(function() {
+      dependencies = pulldeps("import test from 'test'").dependencies;
+    });
+
+    it("then dependencies length is `1`", function() {
+      expect(dependencies.length).to.equal(1);
     });
 
     it("then dependencies[0] is `test`", function() {
-      expect(dependecies[0]).to.equal("test");
+      expect(dependencies[0].name).to.equal("test");
     });
   });
 
   describe("When parsing a single `import` with an aliased named export", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("import { test as t } from 'test'").dependencies;
+    before(function() {
+      dependencies = pulldeps("import { test as t } from 'test'").dependencies;
     });
 
     it("then dependencies length is `1`", function() {
-      expect(dependecies.length).to.equal(1);
+      expect(dependencies.length).to.equal(1);
     });
 
     it("then dependencies[0] is `test`", function() {
-      expect(dependecies[0]).to.equal("test");
+      expect(dependencies[0].name).to.equal("test");
     });
   });
 
   describe("When parsing a single `import` with no named export", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("import 'test'").dependencies;
+    before(function() {
+      dependencies = pulldeps("import 'test'").dependencies;
     });
 
     it("then dependencies length is `1`", function() {
-      expect(dependecies.length).to.equal(1);
+      expect(dependencies.length).to.equal(1);
     });
 
     it("then dependencies[0] is `test`", function() {
-      expect(dependecies[0]).to.equal("test");
+      expect(dependencies[0].name).to.equal("test");
     });
   });
 
   describe("When parsing single `require`", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("require('test')").dependencies;
+    before(function() {
+      dependencies = pulldeps("require('test')").dependencies;
     });
 
     it("then dependencies length is `1`", function() {
-      expect(dependecies.length).to.equal(1);
+      expect(dependencies.length).to.equal(1);
     });
 
     it("then dependencies[0] is `test`", function() {
-      expect(dependecies[0]).to.equal("test");
+      expect(dependencies[0].name).to.equal("test");
     });
   });
 
 
   describe("When parsing single `require` with an array of dependencies", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("require(['test'])").dependencies;
+    before(function() {
+      dependencies = pulldeps("require(['test'])").dependencies;
     });
 
     it("then dependencies length is `0`", function() {
-      expect(dependecies.length).to.equal(0);
+      expect(dependencies.length).to.equal(0);
     });
   });
 
 
   describe("When parsing single `require` and `use strict`", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("'use strict'; require('test')").dependencies;
+    before(function() {
+      dependencies = pulldeps("'use strict'; require('test')").dependencies;
     });
 
     it("then dependencies length is `1`", function() {
-      expect(dependecies.length).to.equal(1);
+      expect(dependencies.length).to.equal(1);
     });
 
     it("then dependencies[0] is `test`", function() {
-      expect(dependecies[0]).to.equal("test");
+      expect(dependencies[0].name).to.equal("test");
     });
   });
 
 
   describe("When parsing single `require` assigned to a variable", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("var test = require('test')").dependencies;
+    before(function() {
+      dependencies = pulldeps("var test = require('test')").dependencies;
     });
 
     it("then dependencies length is `1`", function() {
-      expect(dependecies.length).to.equal(1);
+      expect(dependencies.length).to.equal(1);
     });
 
     it("then dependencies[0] is `test`", function() {
-      expect(dependecies[0]).to.equal("test");
+      expect(dependencies[0].name).to.equal("test");
     });
   });
 
 
   describe("When parsing single `require` assigned to a variable in an if statement", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("var x = true; if(x){var test = require('test')}").dependencies;
+    before(function() {
+      dependencies = pulldeps("var x = true; if(x){var test = require('test')}").dependencies;
     });
 
     it("then dependencies length is `1`", function() {
-      expect(dependecies.length).to.equal(1);
+      expect(dependencies.length).to.equal(1);
     });
 
     it("then dependencies[0] is `test`", function() {
-      expect(dependecies[0]).to.equal("test");
+      expect(dependencies[0].name).to.equal("test");
     });
   });
 
 
   describe("When parsing single `define` with an array", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("define(['test'], function() {})").dependencies;
+    before(function() {
+      dependencies = pulldeps("define(['test'], function() {})").dependencies;
     });
 
     it("then dependencies length is `1`", function() {
-      expect(dependecies.length).to.equal(1);
+      expect(dependencies.length).to.equal(1);
     });
 
     it("then dependencies[0] is `test`", function() {
-      expect(dependecies[0]).to.equal("test");
+      expect(dependencies[0].name).to.equal("test");
     });
   });
 
 
   describe("When parsing single named `define` with an array of two dependencies", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("define('whatever name', ['test1', 'test2'], function() {})").dependencies;
+    before(function() {
+      dependencies = pulldeps("define('whatever name', ['test1', 'test2'], function() {})").dependencies;
     });
 
     it("then dependencies length is `2`", function() {
-      expect(dependecies.length).to.equal(2);
+      expect(dependencies.length).to.equal(2);
     });
 
     it("then dependencies[0] is `test1`", function() {
-      expect(dependecies[0]).to.equal("test1");
+      expect(dependencies[0].name).to.equal("test1");
     });
 
     it("then dependencies[1] is `test2`", function() {
-      expect(dependecies[1]).to.equal("test2");
+      expect(dependencies[1].name).to.equal("test2");
     });
   });
 
 
   describe("When parsing single named `define` with an array of two dependencies and two require statements and one is an array", function() {
-    beforeEach(function() {
-      dependecies = pulldeps("define('whatever name', ['test1', 'test2'], function() {require('test3'); require(['test4']);})").dependencies;
+    before(function() {
+      dependencies = pulldeps("define('whatever name', ['test1', 'test2'], function() {require('test3'); require(['test4']);})").dependencies;
     });
 
     it("then dependencies length is `3`", function() {
-      expect(dependecies.length).to.equal(3);
+      expect(dependencies.length).to.equal(3);
     });
 
     it("then dependencies[0] is `test3`", function() {
-      expect(dependecies[0]).to.equal("test3");
+      expect(dependencies[0].name).to.equal("test3");
     });
 
     it("then dependencies[1] is `test1`", function() {
-      expect(dependecies[1]).to.equal("test1");
+      expect(dependencies[1].name).to.equal("test1");
     });
 
     it("then dependencies[2] is `test2`", function() {
-      expect(dependecies[2]).to.equal("test2");
+      expect(dependencies[2].name).to.equal("test2");
     });
   });
 });


### PR DESCRIPTION
this introduces logic for handling dynamic ESM imports. The generated meta data is different. It now contains a `dynamic` flag and a `type`, along with the `name` of the dependency. The result is no longer an array of strings so consumers of this library will need to adjust.